### PR TITLE
Add API to plot area to control the render loop timer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # C++ objects and libs
 
+build/
 out/
 exported/
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,14 +8,14 @@ set(SRC
 )
 
 set(HEADERS
-  "mainwindow.h.h"
+  "mainwindow.h"
 )
 
 set(UI
   "mainwindow.ui"
 )
 
-add_executable(plot ${SRC} ${UI})
+add_executable(plot ${SRC} ${UI} ${HEADERS})
 target_link_libraries(plot realtimeplot Qt5::Widgets Qt5::Core)
 
 #export(TARGETS realtimeplot FILE ${CMAKE_SOURCE_DIR}/external/realtimeplot.cmake)

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -20,8 +20,10 @@ MainWindow::MainWindow(QWidget *parent) :
         ui->plotArea->addPointStream(stream);
     }
 
-    ui->playPauseButton->setText("Play");
     ui->plotArea->setWindowLengthInSeconds(4.0);
+    // Start on Running State so we can see something on the screen.
+    ui->playPauseButton->setText(QPushButton::tr("Pause"));
+    Q_ASSERT(ui->plotArea->start());
 
     connect(ui->playPauseButton, &QPushButton::released, this, [=]() {
         qDebug() << "Play/Pause Clicked";

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1,8 +1,9 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
-#include <QDebug>
 #include <qmath.h>
+#include <QDebug>
+#include <QTranslator>
 
 #define POINT_STREAM_NUM 4
 
@@ -19,9 +20,22 @@ MainWindow::MainWindow(QWidget *parent) :
         ui->plotArea->addPointStream(stream);
     }
 
+    ui->playPauseButton->setText("Play");
     ui->plotArea->setWindowLengthInSeconds(4.0);
 
-    startTimer(SAMPLE_GENERATION_PERIOD);
+    connect(ui->playPauseButton, &QPushButton::released, this, [=]() {
+        qDebug() << "Play/Pause Clicked";
+        auto state = ui->plotArea->getState();
+        if (state == PlotArea::State::Running) {
+            ui->plotArea->stop();
+            ui->playPauseButton->setText(QPushButton::tr("Play"));
+        } else {
+            Q_ASSERT(ui->plotArea->start());
+            ui->playPauseButton->setText(QPushButton::tr("Pause"));
+        }
+    });
+
+    dataGenerationTimer = startTimer(SAMPLE_GENERATION_PERIOD);
 }
 
 MainWindow::~MainWindow()
@@ -31,7 +45,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::timerEvent(QTimerEvent *event)
 {
-    Q_UNUSED(event)
+    Q_ASSERT(dataGenerationTimer == event->timerId());
 
     constexpr double freq = 1.0; // 2Hz
     const double samplePeriod = static_cast<double>(SAMPLE_GENERATION_PERIOD)/1000.0;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -16,6 +16,7 @@ class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
+
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
@@ -24,8 +25,9 @@ public:
 private:
     Ui::MainWindow *ui;
 
-    static const int SAMPLE_GENERATION_PERIOD = 5; // 5 ms
+    static constexpr int SAMPLE_GENERATION_PERIOD = 5; // 5 ms
     quint64 sampleNumber = 0;
+    int dataGenerationTimer = 0;
 
     QList <QSharedPointer<PointStream<point_t>>> dataPoints;
 

--- a/app/mainwindow.ui
+++ b/app/mainwindow.ui
@@ -31,7 +31,57 @@
      <number>3</number>
     </property>
     <item>
-     <widget class="PlotArea" name="plotArea" native="true"/>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item>
+       <widget class="QPushButton" name="playPauseButton">
+        <property name="text">
+         <string>Play / Pause</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeType">
+       <enum>QSizePolicy::Fixed</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>10</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="PlotArea" name="plotArea" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>
@@ -41,7 +91,7 @@
      <x>0</x>
      <y>0</y>
      <width>400</width>
-     <height>22</height>
+     <height>24</height>
     </rect>
    </property>
   </widget>

--- a/lib/realtimeplot/CMakeLists.txt
+++ b/lib/realtimeplot/CMakeLists.txt
@@ -16,7 +16,7 @@ set(UI
   "plotarea.ui"
 )
 
-add_library(realtimeplot ${SRC} ${UI})
+add_library(realtimeplot ${HEADERS} ${SRC} ${UI})
 target_link_libraries(realtimeplot qcustomplot cpp_ringbuffer Qt5::Widgets)
 target_include_directories(realtimeplot PUBLIC "../")
 

--- a/lib/realtimeplot/plotarea.cpp
+++ b/lib/realtimeplot/plotarea.cpp
@@ -1,10 +1,12 @@
 #include "plotarea.h"
 #include "ui_plotarea.h"
 
+#include <chrono>
 #include <qmath.h>
 
 PlotArea::PlotArea(QWidget *parent) :
     QCustomPlot(parent),
+    timerId(0),
     ui(new Ui::PlotArea)
 {
     ui->setupUi(this);
@@ -18,8 +20,6 @@ PlotArea::PlotArea(QWidget *parent) :
     wideAxisRect->removeAxis(wideAxisRect->axis(QCPAxis::atTop));
     wideAxisRect->axis(QCPAxis::atLeft)->setRange(-1.5, 1.5);
     plotLayout()->addElement(0, 0, wideAxisRect);
-
-    startTimer(TIME_BETWEEN_FRAMES_MS);
 }
 
 PlotArea::~PlotArea()
@@ -59,6 +59,25 @@ void PlotArea::timerEvent(QTimerEvent *event)
 {
     Q_UNUSED(event)
     update();
+}
+
+bool PlotArea::start(std::chrono::milliseconds refresh_ms) {
+    if (timerId != 0) {
+        return false;
+    }
+    timerId = startTimer(std::chrono::milliseconds(20));
+    return timerId != 0;
+}
+
+void PlotArea::stop() {
+    if (timerId != 0) {
+        killTimer(timerId);
+        timerId = 0;
+    }
+}
+
+PlotArea::State PlotArea::getState() {
+    return timerId == 0 ? State::Stopped : State::Running;
 }
 
 void PlotArea::update()

--- a/lib/realtimeplot/plotarea.cpp
+++ b/lib/realtimeplot/plotarea.cpp
@@ -65,7 +65,7 @@ bool PlotArea::start(std::chrono::milliseconds refresh_ms) {
     if (timerId != 0) {
         return false;
     }
-    timerId = startTimer(std::chrono::milliseconds(20));
+    timerId = startTimer(std::chrono::milliseconds(refresh_ms));
     return timerId != 0;
 }
 

--- a/lib/realtimeplot/plotarea.h
+++ b/lib/realtimeplot/plotarea.h
@@ -1,8 +1,12 @@
 #ifndef PLOTAREA_H
 #define PLOTAREA_H
 
+#include <chrono>
+
 #include <QWidget>
 #include <QSharedPointer>
+#include <QTimer>
+
 #include <qcustomplot/qcustomplot.h>
 
 #include "pointstream.h"
@@ -11,33 +15,50 @@ namespace Ui {
 class PlotArea;
 }
 
+/**
+ * PlotAre refer to a a graph area where N curves can be ploted.
+ * Each curve is backed by a PointStream.
+ */  
 class PlotArea : public QCustomPlot
 {
     Q_OBJECT
 
 public:
 
-    static const int TIME_BETWEEN_FRAMES_MS = 50; //100 ms - 20fps
+    enum class State {
+       Stopped = 0,
+       Running = 1,
+    };
+
+    static constexpr std::chrono::milliseconds TIME_BETWEEN_FRAMES_MS{1000 / 3}; // 30 fps
 
     explicit PlotArea(QWidget *parent = nullptr);
 
     ~PlotArea();
 
     void addPointStream (QSharedPointer<PointStream<point_t>> points);
-
+    
+    /// Start periodic plot refresh at $refresh_ms.
+    bool start(std::chrono::milliseconds refresh_ms = TIME_BETWEEN_FRAMES_MS);
+    /// Stop periodic plot refresh.
+    void stop();
+    /// Update plot area with the most recent data available in the streams.
     void update();
+    State getState();
 
     double getWindowLengthInSeconds() const;
-
     void setWindowLengthInSeconds(double value);
+
+protected:
 
     void timerEvent(QTimerEvent *event);
 
 private:
 
     Ui::PlotArea *ui;
-    QMap<PointStream<point_t> *, QCPGraph *> pointStream;
-    QMap<PointStream<point_t> *, QSharedPointer<PointStream<point_t> > > references;
+    QMap<PointStream<point_t>*, QCPGraph *> pointStream;
+    QMap<PointStream<point_t>*, QSharedPointer<PointStream<point_t>>> references;
+    int timerId;
     double windowLengthInSeconds = 4.0;
 };
 

--- a/lib/realtimeplot/plotarea.h
+++ b/lib/realtimeplot/plotarea.h
@@ -29,11 +29,9 @@ public:
        Stopped = 0,
        Running = 1,
     };
-
-    static constexpr std::chrono::milliseconds TIME_BETWEEN_FRAMES_MS{1000 / 3}; // 30 fps
+    static constexpr std::chrono::milliseconds TIME_BETWEEN_FRAMES_MS{1000 / 60}; // 60 fps
 
     explicit PlotArea(QWidget *parent = nullptr);
-
     ~PlotArea();
 
     void addPointStream (QSharedPointer<PointStream<point_t>> points);


### PR DESCRIPTION
This pull request introduces APIs on _PlotArea_ that enables callers to control the render timer. I've also added a control button that allows pause/play of the plot in the sample app to demonstrate the functionality. It's worth noting that the play/pause mechanism is only applicable to the render loop, the data generation will be always running and simulates continuous data acquisition from an an external source.

See screenshots below:

![Screen Shot 2024-08-11 at 10 34 37 PM](https://github.com/user-attachments/assets/c5ff7394-b7e6-4993-b641-8ce1ee264e51)

![Screen Shot 2024-08-11 at 10 34 48 PM](https://github.com/user-attachments/assets/3ddda122-d203-493d-bec1-a8e079cfff57)
